### PR TITLE
Add getSharedDir() : non user-specific data/config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Currently, __AppDirs__ has the following methods.
 - getUserLogDir
 - getSiteDataDir
 - getSiteConfigDir
+- getSharedDir
 
 Here is a test program and the output on some platforms.
 
@@ -60,6 +61,8 @@ public class AppDirTest {
       + appDirs.getSiteConfigDir("myapp", "1.2.3", "harawata"));
     System.out.println("Site config dir (multi path): "
       + appDirs.getSiteConfigDir("myapp", "1.2.3", "harawata", true));
+    System.out.println("Shared dir: "
+      + appDirs.getSharedDir("myapp", "1.2.3", "harawata"));
   }
 }
 ```
@@ -77,6 +80,7 @@ Site data dir: /Library/Application Support/myapp/1.2.3
 Site data dir (multi path): /Library/Application Support/myapp/1.2.3
 Site config dir: /Library/Application Support/myapp/1.2.3
 Site config dir (multi path): /Library/Application Support/myapp/1.2.3
+Shared dir: /Users/Shared/Library/Application Support/myapp/1.2.3
 ```
 - _appAuthor_ parameter is not used on Mac OS X.
 - _roaming_ and _multiPath_ parameters have no effect on Mac OS X.
@@ -93,6 +97,7 @@ Site data dir: C:\ProgramData\harawata\myapp\1.2.3
 Site data dir (multi path): C:\ProgramData\harawata\myapp\1.2.3
 Site config dir: C:\ProgramData\harawata\myapp\1.2.3
 Site config dir (multi path): C:\ProgramData\harawata\myapp\1.2.3
+Shared dir: C:\ProgramData\harawata\myapp\1.2.3
 ```
 - Internally calls [SHGetFolderPath](http://msdn.microsoft.com/en-us/library/bb762181%28VS.85%29.aspx) via [Java Native Access (JNA)](https://github.com/twall/jna).
  - Returns CSIDL_LOCAL_APPDATA or CSIDL_APPDATA for user directories.
@@ -111,7 +116,9 @@ Site data dir: /usr/local/share/myapp/1.2.3
 Site data dir (multi path): /usr/local/share/myapp/1.2.3:/usr/share/myapp/1.2.3
 Site config dir: /etc/xdg/myapp/1.2.3
 Site config dir (multi path): /etc/xdg/myapp/1.2.3
+Shared dir: /srv/myapp/1.2.3
 ```
+
 - __AppDirs__ respects [XDG Base Directory Specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) if variables are defined.
  - Returns XDG_DATA_HOME for user data directory.
  - Returns XDG_CONFIG_HOME for user config directory.

--- a/src/main/java/net/harawata/appdirs/AppDirs.java
+++ b/src/main/java/net/harawata/appdirs/AppDirs.java
@@ -53,6 +53,9 @@ public abstract class AppDirs {
   public abstract String getUserLogDir(String appName, String appVersion,
       String appAuthor);
 
+  public abstract String getSharedDir(String appName, String appVersion,
+      String appAuthor);
+
   protected String home() {
     return System.getProperty("user.home");
   }

--- a/src/main/java/net/harawata/appdirs/impl/MacOSXAppDirs.java
+++ b/src/main/java/net/harawata/appdirs/impl/MacOSXAppDirs.java
@@ -51,4 +51,11 @@ public class MacOSXAppDirs extends AppDirs {
       String appAuthor) {
     return buildPath(home(), "/Library/Logs", appName, appVersion);
   }
+
+  @Override
+  public String getSharedDir(String appName, String appVersion,
+      String appAuthor) {
+    return buildPath("/Users/Shared/Library/Application Support", appName,
+        appVersion);
+  }
 }

--- a/src/main/java/net/harawata/appdirs/impl/UnixAppDirs.java
+++ b/src/main/java/net/harawata/appdirs/impl/UnixAppDirs.java
@@ -98,6 +98,12 @@ public class UnixAppDirs extends AppDirs {
     return buildPath(dir, appName, "/logs", appVersion);
   }
 
+  @Override
+  public String getSharedDir(String appName, String appVersion,
+      String appAuthor) {
+    return buildPath("/srv", appName, appVersion);
+  }
+
   public String getOrDefault(String key, String def) {
     String val = sysEnv.get(key);
     return val == null ? def : val;

--- a/src/main/java/net/harawata/appdirs/impl/WindowsAppDirs.java
+++ b/src/main/java/net/harawata/appdirs/impl/WindowsAppDirs.java
@@ -63,6 +63,12 @@ public class WindowsAppDirs extends AppDirs {
         appName, "\\Logs", appVersion);
   }
 
+  @Override
+  public String getSharedDir(String appName, String appVersion,
+      String appAuthor) {
+    return buildPath(getCommonAppData(), appAuthor, appName, appVersion);
+  }
+
   protected String getAppData() {
     return folderResolver.resolveFolder(FolderId.APPDATA);
   }

--- a/src/test/java/net/harawata/appdirs/impl/MacOSXAppDirTest.java
+++ b/src/test/java/net/harawata/appdirs/impl/MacOSXAppDirTest.java
@@ -144,6 +144,18 @@ public class MacOSXAppDirTest {
         appDirs.getSiteConfigDir("myapp", "1.2.3", "harawata", true));
   }
 
+  @Test
+  public void testgetSharedDir() {
+    assertEquals("/Users/Shared/Library/Application Support",
+        appDirs.getSharedDir(null, null, null));
+    assertEquals("/Users/Shared/Library/Application Support/myapp",
+        appDirs.getSharedDir("myapp", null, null));
+    assertEquals("/Users/Shared/Library/Application Support/myapp/1.2.3",
+        appDirs.getSharedDir("myapp", "1.2.3", null));
+    assertEquals("/Users/Shared/Library/Application Support/myapp/1.2.3",
+        appDirs.getSharedDir("myapp", "1.2.3", "harawata"));
+  }
+
   @AfterClass
   public static void tearDown() {
     if (origHome == null)

--- a/src/test/java/net/harawata/appdirs/impl/UnixAppDirTest.java
+++ b/src/test/java/net/harawata/appdirs/impl/UnixAppDirTest.java
@@ -174,6 +174,17 @@ public class UnixAppDirTest {
         appDirs.getSiteConfigDir("myapp", "1.2.3", "harawata", true));
   }
 
+  @Test
+  public void testgetSharedDir() {
+    AppDirs appDirs = getAppDirs();
+    assertEquals("/srv", appDirs.getSharedDir(null, null, null));
+    assertEquals("/srv/myapp", appDirs.getSharedDir("myapp", null, null));
+    assertEquals("/srv/myapp/1.2.3",
+        appDirs.getSharedDir("myapp", "1.2.3", null));
+    assertEquals("/srv/myapp/1.2.3",
+        appDirs.getSharedDir("myapp", "1.2.3", "harawata"));
+  }
+
   private AppDirs getAppDirs() {
     return getAppDirs(new HashMap<String, String>());
   }

--- a/src/test/java/net/harawata/appdirs/impl/WindowsAppDirTest.java
+++ b/src/test/java/net/harawata/appdirs/impl/WindowsAppDirTest.java
@@ -174,6 +174,21 @@ public class WindowsAppDirTest {
         appDirs.getSiteConfigDir("myapp", "1.2.3", "harawata", true));
   }
 
+  @Test
+  public void testgetSharedDir() {
+    assertEquals("C:\\Documents and Settings\\All Users\\Application Data",
+        appDirs.getSharedDir(null, null, null));
+    assertEquals(
+        "C:\\Documents and Settings\\All Users\\Application Data\\myapp",
+        appDirs.getSharedDir("myapp", null, null));
+    assertEquals(
+        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\1.2.3",
+        appDirs.getSharedDir("myapp", "1.2.3", null));
+    assertEquals(
+        "C:\\Documents and Settings\\All Users\\Application Data\\harawata\\myapp\\1.2.3",
+        appDirs.getSharedDir("myapp", "1.2.3", "harawata"));
+  }
+
   @AfterClass
   public static void tearDown() {
     if (origFileSeparator == null)

--- a/src/test/java/net/harawata/appdirs/it/RealPathTest.java
+++ b/src/test/java/net/harawata/appdirs/it/RealPathTest.java
@@ -77,6 +77,13 @@ public class RealPathTest {
   }
 
   @Test
+  public void testRealPathMacSharedDir() {
+    assumeTrue(SystemUtils.IS_OS_MAC_OSX);
+    assertEquals("/Users/Shared/Library/Application Support",
+        appDirs.getSharedDir(null, null, null));
+  }
+
+  @Test
   public void testRealPathLinuxUserDataDir() {
     assumeTrue(SystemUtils.IS_OS_LINUX);
     assertEquals(home + "/.local/share",
@@ -112,6 +119,12 @@ public class RealPathTest {
   public void testRealPathLinuxSiteConfigDir() {
     assumeTrue(SystemUtils.IS_OS_LINUX);
     assertEquals("/etc/xdg", appDirs.getSiteConfigDir(null, null, null));
+  }
+
+  @Test
+  public void testRealPathLinuxSharedDir() {
+    assumeTrue(SystemUtils.IS_OS_LINUX);
+    assertEquals("/srv", appDirs.getSharedDir(null, null, null));
   }
 
   @Test
@@ -152,5 +165,11 @@ public class RealPathTest {
   public void testRealPathWinSiteConfigDir() {
     assumeTrue(SystemUtils.IS_OS_WINDOWS);
     assertEquals("C:\\ProgramData", appDirs.getSiteConfigDir(null, null, null));
+  }
+
+  @Test
+  public void testRealPathWinSharedDir() {
+    assumeTrue(SystemUtils.IS_OS_WINDOWS);
+    assertEquals("C:\\ProgramData", appDirs.getSharedDir(null, null, null));
   }
 }


### PR DESCRIPTION
As discussed in #30 , this PR adds a new method `getSharedDir()` which returns the following directories.

- macOS : `/Users/Shared`
- Windows : `C:\ProgramData`
- *nix : `/srv`

On macOS, `/Users/Shared` is writable to all users and this could be useful to desktop applications, for example.
I am not sure if this is useful on other platforms.
