### PR TITLE
Made appAuthor optional even on Windows

### DIFF
--- a/src/main/java/net/harawata/appdirs/impl/WindowsAppDirs.java
+++ b/src/main/java/net/harawata/appdirs/impl/WindowsAppDirs.java
@@ -31,8 +31,7 @@ public class WindowsAppDirs extends AppDirs {
   public String getUserDataDir(String appName, String appVersion,
       String appAuthor, boolean roaming) {
     String dir = roaming ? getAppData() : getLocalAppData();
-    return buildPath(dir, appAuthor == null ? appName : appAuthor, appName,
-        appVersion);
+    return buildPath(dir, appAuthor, appName, appVersion);
   }
 
   public String getUserConfigDir(String appName, String appVersion,
@@ -42,14 +41,13 @@ public class WindowsAppDirs extends AppDirs {
 
   public String getUserCacheDir(String appName, String appVersion,
       String appAuthor) {
-    return buildPath(getLocalAppData(), appAuthor == null ? appName : appAuthor,
-        appName, "\\Cache", appVersion);
+    return buildPath(getLocalAppData(), appAuthor, appName, "\\Cache",
+        appVersion);
   }
 
   public String getSiteDataDir(String appName, String appVersion,
       String appAuthor, boolean multiPath) {
-    return buildPath(getCommonAppData(),
-        appAuthor == null ? appName : appAuthor, appName, appVersion);
+    return buildPath(getCommonAppData(), appAuthor, appName, appVersion);
   }
 
   public String getSiteConfigDir(String appName, String appVersion,
@@ -59,8 +57,8 @@ public class WindowsAppDirs extends AppDirs {
 
   public String getUserLogDir(String appName, String appVersion,
       String appAuthor) {
-    return buildPath(getLocalAppData(), appAuthor == null ? appName : appAuthor,
-        appName, "\\Logs", appVersion);
+    return buildPath(getLocalAppData(), appAuthor, appName, "\\Logs",
+        appVersion);
   }
 
   protected String getAppData() {

--- a/src/test/java/net/harawata/appdirs/impl/WindowsAppDirTest.java
+++ b/src/test/java/net/harawata/appdirs/impl/WindowsAppDirTest.java
@@ -44,16 +44,16 @@ public class WindowsAppDirTest {
     assertEquals("C:\\Documents and Settings\\harawata\\Application Data",
         appDirs.getUserDataDir(null, null, null, true));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\myapp",
+        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp",
         appDirs.getUserDataDir("myapp", null, null));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Application Data\\myapp\\myapp",
+        "C:\\Documents and Settings\\harawata\\Application Data\\myapp",
         appDirs.getUserDataDir("myapp", null, null, true));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\myapp\\1.2.3",
+        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\1.2.3",
         appDirs.getUserDataDir("myapp", "1.2.3", null));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Application Data\\myapp\\myapp\\1.2.3",
+        "C:\\Documents and Settings\\harawata\\Application Data\\myapp\\1.2.3",
         appDirs.getUserDataDir("myapp", "1.2.3", null, true));
     assertEquals(
         "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\harawata\\myapp\\1.2.3",
@@ -71,16 +71,16 @@ public class WindowsAppDirTest {
     assertEquals("C:\\Documents and Settings\\harawata\\Application Data",
         appDirs.getUserConfigDir(null, null, null, true));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\myapp",
+        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp",
         appDirs.getUserConfigDir("myapp", null, null));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Application Data\\myapp\\myapp",
+        "C:\\Documents and Settings\\harawata\\Application Data\\myapp",
         appDirs.getUserConfigDir("myapp", null, null, true));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\myapp\\1.2.3",
+        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\1.2.3",
         appDirs.getUserConfigDir("myapp", "1.2.3", null));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Application Data\\myapp\\myapp\\1.2.3",
+        "C:\\Documents and Settings\\harawata\\Application Data\\myapp\\1.2.3",
         appDirs.getUserConfigDir("myapp", "1.2.3", null, true));
     assertEquals(
         "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\harawata\\myapp\\1.2.3",
@@ -96,10 +96,10 @@ public class WindowsAppDirTest {
         "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\Cache",
         appDirs.getUserCacheDir(null, null, null));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\myapp\\Cache",
+        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\Cache",
         appDirs.getUserCacheDir("myapp", null, null));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\myapp\\Cache\\1.2.3",
+        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\Cache\\1.2.3",
         appDirs.getUserCacheDir("myapp", "1.2.3", null));
     assertEquals(
         "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\harawata\\myapp\\Cache\\1.2.3",
@@ -112,10 +112,10 @@ public class WindowsAppDirTest {
         "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\Logs",
         appDirs.getUserLogDir(null, null, null));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\myapp\\Logs",
+        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\Logs",
         appDirs.getUserLogDir("myapp", null, null));
     assertEquals(
-        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\myapp\\Logs\\1.2.3",
+        "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\myapp\\Logs\\1.2.3",
         appDirs.getUserLogDir("myapp", "1.2.3", null));
     assertEquals(
         "C:\\Documents and Settings\\harawata\\Local Settings\\Application Data\\harawata\\myapp\\Logs\\1.2.3",
@@ -129,16 +129,16 @@ public class WindowsAppDirTest {
     assertEquals("C:\\Documents and Settings\\All Users\\Application Data",
         appDirs.getSiteDataDir(null, null, null, true));
     assertEquals(
-        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\myapp",
+        "C:\\Documents and Settings\\All Users\\Application Data\\myapp",
         appDirs.getSiteDataDir("myapp", null, null));
     assertEquals(
-        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\myapp",
+        "C:\\Documents and Settings\\All Users\\Application Data\\myapp",
         appDirs.getSiteDataDir("myapp", null, null, true));
     assertEquals(
-        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\myapp\\1.2.3",
+        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\1.2.3",
         appDirs.getSiteDataDir("myapp", "1.2.3", null));
     assertEquals(
-        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\myapp\\1.2.3",
+        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\1.2.3",
         appDirs.getSiteDataDir("myapp", "1.2.3", null, true));
     assertEquals(
         "C:\\Documents and Settings\\All Users\\Application Data\\harawata\\myapp\\1.2.3",
@@ -155,16 +155,16 @@ public class WindowsAppDirTest {
     assertEquals("C:\\Documents and Settings\\All Users\\Application Data",
         appDirs.getSiteConfigDir(null, null, null, true));
     assertEquals(
-        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\myapp",
+        "C:\\Documents and Settings\\All Users\\Application Data\\myapp",
         appDirs.getSiteConfigDir("myapp", null, null));
     assertEquals(
-        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\myapp",
+        "C:\\Documents and Settings\\All Users\\Application Data\\myapp",
         appDirs.getSiteConfigDir("myapp", null, null, true));
     assertEquals(
-        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\myapp\\1.2.3",
+        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\1.2.3",
         appDirs.getSiteConfigDir("myapp", "1.2.3", null));
     assertEquals(
-        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\myapp\\1.2.3",
+        "C:\\Documents and Settings\\All Users\\Application Data\\myapp\\1.2.3",
         appDirs.getSiteConfigDir("myapp", "1.2.3", null, true));
     assertEquals(
         "C:\\Documents and Settings\\All Users\\Application Data\\harawata\\myapp\\1.2.3",


### PR DESCRIPTION
It thought that `appAuthor` was required on Windows, but some (most?) users want to omit it.
This may be a backward incompatible change and I might consider making it configurable if this causes many problems.
See the changes in the test for the differences.
