### PR TITLE
Modify `AppDirsFactory.getInstance()` to return the singleton instance

### DIFF
--- a/src/main/java/net/harawata/appdirs/AppDirsFactory.java
+++ b/src/main/java/net/harawata/appdirs/AppDirsFactory.java
@@ -25,16 +25,32 @@ public class AppDirsFactory {
     super();
   }
 
+  /**
+   * @return platform dependent implementation of <code>AppDirs</code>. Since
+   *         1.4.0, the same instance is returned for repeated invocations.
+   */
   public static AppDirs getInstance() {
-    String os = System.getProperty("os.name").toLowerCase();
-    if (os.startsWith("mac os x")) {
-      return new MacOSXAppDirs();
-    } else if (os.startsWith("windows")) {
-      WindowsFolderResolver folderResolver = new ShellFolderResolver();
-      return new WindowsAppDirs(folderResolver);
-    } else {
-      // Assume other *nix.
-      return new UnixAppDirs();
+    return Holder.INSTANCE;
+  }
+
+  /** Singleton instance holder. */
+  private static class Holder {
+    static final AppDirs INSTANCE = create();
+
+    static AppDirs create() {
+      String os = System.getProperty("os.name").toLowerCase();
+      if (os.startsWith("mac os x")) {
+        return new MacOSXAppDirs();
+      } else if (os.startsWith("windows")) {
+        WindowsFolderResolver folderResolver = new ShellFolderResolver();
+        return new WindowsAppDirs(folderResolver);
+      } else {
+        // Assume other *nix.
+        return new UnixAppDirs();
+      }
+    }
+
+    private Holder() {
     }
   }
 }

--- a/src/test/java/net/harawata/appdirs/AppDirsFactoryTest.java
+++ b/src/test/java/net/harawata/appdirs/AppDirsFactoryTest.java
@@ -15,8 +15,9 @@
 package net.harawata.appdirs;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
-import org.junit.After;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
 
 import net.harawata.appdirs.impl.MacOSXAppDirs;
@@ -24,31 +25,32 @@ import net.harawata.appdirs.impl.UnixAppDirs;
 import net.harawata.appdirs.impl.WindowsAppDirs;
 
 public class AppDirsFactoryTest {
-  private static String origOs;
 
   @Test
   public void testGetInstance_MacOSX() {
-    origOs = System.setProperty("os.name", "Mac OS X");
+    assumeTrue(SystemUtils.IS_OS_MAC_OSX);
     AppDirs appDirs = AppDirsFactory.getInstance();
     assertEquals(MacOSXAppDirs.class, appDirs.getClass());
   }
 
   @Test
   public void testGetInstance_Unix() {
-    origOs = System.setProperty("os.name", "OpenBSD");
+    assumeFalse(SystemUtils.IS_OS_MAC_OSX || SystemUtils.IS_OS_WINDOWS);
     AppDirs appDirs = AppDirsFactory.getInstance();
     assertEquals(UnixAppDirs.class, appDirs.getClass());
   }
 
   @Test
   public void testGetInstance_Windows() {
-    origOs = System.setProperty("os.name", "Windows 7");
+    assumeTrue(SystemUtils.IS_OS_WINDOWS);
     AppDirs appDirs = AppDirsFactory.getInstance();
     assertEquals(WindowsAppDirs.class, appDirs.getClass());
   }
 
-  @After
-  public void resetProperty() {
-    System.setProperty("os.name", origOs);
+  @Test
+  public void verifySingleton() {
+    AppDirs appDirs1 = AppDirsFactory.getInstance();
+    AppDirs appDirs2 = AppDirsFactory.getInstance();
+    assertSame(appDirs1, appDirs2);
   }
 }


### PR DESCRIPTION
I couldn't verify whether `WindowsAppDirs` is thread-safe or not.
It looks reasonable to assume it is, but if the assumption is wrong, we might have to revert this.

This won't break any existing solutions, but I plan to bump the minor version to 1.4.0 just in case.

Should fix #117

Cc: @koppor