### PR TITLE
Use enum for single instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ On Unix/Linux : ```/home/<account>/.local/share/<AppName>```
 With __AppDirs__, you can get the path depending on the runtime platform with the following code.
 
 ``` java
-AppDirs appDirs = AppDirsFactory.getInstance();
+AppDirs appDirs = AppDirsFactory.INSTANCE.getAppDirs();
 appDirs.getUserDataDir("<AppName>", null, "<AppAuthor>");
 ```
 __AppDirs__ is loosely based on [a python module](https://github.com/ActiveState/appdirs) with the same name.  
@@ -62,7 +62,7 @@ import net.harawata.appdirs.AppDirsFactory;
 
 public class AppDirTest {
   public static void main(String[] args) {
-    AppDirs appDirs = AppDirsFactory.getInstance();
+    AppDirs appDirs = AppDirsFactory.INSTANCE.getAppDirs();
     System.out.println("User data dir: " + appDirs.getUserDataDir("myapp", "1.2.3", "harawata"));
     System.out.println("User data dir (roaming): "
       + appDirs.getUserDataDir("myapp", "1.2.3", "harawata", true));

--- a/src/main/java/net/harawata/appdirs/AppDirsFactory.java
+++ b/src/main/java/net/harawata/appdirs/AppDirsFactory.java
@@ -20,37 +20,30 @@ import net.harawata.appdirs.impl.UnixAppDirs;
 import net.harawata.appdirs.impl.WindowsAppDirs;
 import net.harawata.appdirs.impl.WindowsFolderResolver;
 
-public class AppDirsFactory {
-  private AppDirsFactory() {
-    super();
+/**
+ * @implNote Factor implemented as enum to ensure thread safety and lazy initialization.
+ *           Details at <a href="https://stackoverflow.com/a/50951454/873282">stackoverflow answer</a>.
+ *           <a href="https://softwareengineering.stackexchange.com/a/401799/52607">A factory does not need to create a new instance every time.</a>
+ */
+public enum AppDirsFactory {
+  INSTANCE;
+
+  public AppDirs getAppDirs() {
+    return APP_DIRS_INSTANCE;
   }
 
-  /**
-   * @return platform dependent implementation of <code>AppDirs</code>. Since
-   *         1.4.0, the same instance is returned for repeated invocations.
-   */
-  public static AppDirs getInstance() {
-    return Holder.INSTANCE;
-  }
+  private static final AppDirs APP_DIRS_INSTANCE = create();
 
-  /** Singleton instance holder. */
-  private static class Holder {
-    static final AppDirs INSTANCE = create();
-
-    static AppDirs create() {
-      String os = System.getProperty("os.name").toLowerCase();
-      if (os.startsWith("mac os x")) {
-        return new MacOSXAppDirs();
-      } else if (os.startsWith("windows")) {
-        WindowsFolderResolver folderResolver = new ShellFolderResolver();
-        return new WindowsAppDirs(folderResolver);
-      } else {
-        // Assume other *nix.
-        return new UnixAppDirs();
-      }
-    }
-
-    private Holder() {
+  private static AppDirs create() {
+    String os = System.getProperty("os.name").toLowerCase();
+    if (os.startsWith("mac os x")) {
+      return new MacOSXAppDirs();
+    } else if (os.startsWith("windows")) {
+      WindowsFolderResolver folderResolver = new ShellFolderResolver();
+      return new WindowsAppDirs(folderResolver);
+    } else {
+      // Assume other *nix.
+      return new UnixAppDirs();
     }
   }
 }

--- a/src/test/java/net/harawata/appdirs/AppDirsFactoryTest.java
+++ b/src/test/java/net/harawata/appdirs/AppDirsFactoryTest.java
@@ -29,28 +29,28 @@ public class AppDirsFactoryTest {
   @Test
   public void testGetInstance_MacOSX() {
     assumeTrue(SystemUtils.IS_OS_MAC_OSX);
-    AppDirs appDirs = AppDirsFactory.getInstance();
+    AppDirs appDirs = AppDirsFactory.INSTANCE.getAppDirs();
     assertEquals(MacOSXAppDirs.class, appDirs.getClass());
   }
 
   @Test
   public void testGetInstance_Unix() {
     assumeFalse(SystemUtils.IS_OS_MAC_OSX || SystemUtils.IS_OS_WINDOWS);
-    AppDirs appDirs = AppDirsFactory.getInstance();
+    AppDirs appDirs = AppDirsFactory.INSTANCE.getAppDirs();
     assertEquals(UnixAppDirs.class, appDirs.getClass());
   }
 
   @Test
   public void testGetInstance_Windows() {
     assumeTrue(SystemUtils.IS_OS_WINDOWS);
-    AppDirs appDirs = AppDirsFactory.getInstance();
+    AppDirs appDirs = AppDirsFactory.INSTANCE.getAppDirs();
     assertEquals(WindowsAppDirs.class, appDirs.getClass());
   }
 
   @Test
   public void verifySingleton() {
-    AppDirs appDirs1 = AppDirsFactory.getInstance();
-    AppDirs appDirs2 = AppDirsFactory.getInstance();
+    AppDirs appDirs1 = AppDirsFactory.INSTANCE.getAppDirs();
+    AppDirs appDirs2 = AppDirsFactory.INSTANCE.getAppDirs();
     assertSame(appDirs1, appDirs2);
   }
 }

--- a/src/test/java/net/harawata/appdirs/it/RealPathTest.java
+++ b/src/test/java/net/harawata/appdirs/it/RealPathTest.java
@@ -30,7 +30,7 @@ public class RealPathTest {
 
   @BeforeClass
   public static void init() {
-    appDirs = AppDirsFactory.getInstance();
+    appDirs = AppDirsFactory.INSTANCE.getAppDirs();
     home = System.getProperty("user.home");
   }
 


### PR DESCRIPTION
Proposal for https://github.com/harawata/appdirs/pull/118#discussion_r1971405599

It was harder than I thought, because `AppDirs` make use of inheritance - instead of composition. I am a fan of inheritance, thus I did not touch that part ^^.

I strictly followed the `enum` pattern. Thus, there is a new `.INSTANCE` for the AppDirsFactory itself -> returning an instance of the factory.

I think, this is the more proper name, but I was not in this part of the Java world the last years.

---

I am a bit undecided whether this is too strict software engineering.

- If it is merged, there will be a 2.0 necessary as the API of AppDirsFactory changed
- If it is NOT merged, it is very OK for me!